### PR TITLE
docs: add model weights section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,6 @@ Set `WAVEKAT_MODEL_DIR` to load from a local directory and skip all downloads.
 All backends produce `AudioFrame<'static>` from [`wavekat-core`](https://github.com/wavekat/wavekat-core) — the same
 type consumed by `wavekat-vad` and `wavekat-turn`.
 
-## Model weights
-
-ONNX-converted weights are published under the [`wavekat`](https://huggingface.co/wavekat) organization on Hugging Face.
-
-| Backend | Repository | Precision |
-|---------|------------|-----------|
-| Qwen3-TTS | [wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX](https://huggingface.co/wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX) | FP32, INT4 |
-
 ## Architecture
 
 ```
@@ -109,6 +101,14 @@ cargo run --example synthesize --features qwen3-tts -- --model-dir /path/to/mode
 _RTF < 1.0 = faster-than-real-time. Lower is better._  
 _To update: run `make bench-csv-cuda` on target hardware, then commit `bench/results/`._
 <!-- bench:end -->
+
+## Model weights
+
+ONNX-converted weights are published under the [`wavekat`](https://huggingface.co/wavekat) organization on Hugging Face.
+
+| Backend | Repository | Precision |
+|---------|------------|-----------|
+| Qwen3-TTS | [wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX](https://huggingface.co/wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX) | FP32, INT4 |
 
 ## Feature flags
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Set `WAVEKAT_MODEL_DIR` to load from a local directory and skip all downloads.
 All backends produce `AudioFrame<'static>` from [`wavekat-core`](https://github.com/wavekat/wavekat-core) — the same
 type consumed by `wavekat-vad` and `wavekat-turn`.
 
+## Model weights
+
+ONNX-converted weights are published under the [`wavekat`](https://huggingface.co/wavekat) organization on Hugging Face.
+
+| Backend | Repository | Precision |
+|---------|------------|-----------|
+| Qwen3-TTS | [wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX](https://huggingface.co/wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX) | FP32, INT4 |
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Same pattern as
 | [Qwen3-TTS](https://huggingface.co/Qwen/Qwen3-TTS) | `qwen3-tts` | ✅ Available | Apache 2.0 |
 | [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | `cosyvoice` | 🚧 Planned | Apache 2.0 |
 
+## Model weights
+
+ONNX-converted weights are published under the [`wavekat`](https://huggingface.co/wavekat) organization on Hugging Face.
+
+| Backend | Repository | Precision |
+|---------|------------|-----------|
+| Qwen3-TTS | [wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX](https://huggingface.co/wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX) | FP32, INT4 |
+
 ## Quick start
 
 ```sh
@@ -101,14 +109,6 @@ cargo run --example synthesize --features qwen3-tts -- --model-dir /path/to/mode
 _RTF < 1.0 = faster-than-real-time. Lower is better._  
 _To update: run `make bench-csv-cuda` on target hardware, then commit `bench/results/`._
 <!-- bench:end -->
-
-## Model weights
-
-ONNX-converted weights are published under the [`wavekat`](https://huggingface.co/wavekat) organization on Hugging Face.
-
-| Backend | Repository | Precision |
-|---------|------------|-----------|
-| Qwen3-TTS | [wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX](https://huggingface.co/wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX) | FP32, INT4 |
 
 ## Feature flags
 


### PR DESCRIPTION
## Summary
- Add a dedicated **Model weights** section to the README pointing to the ONNX weights hosted under the [`wavekat`](https://huggingface.co/wavekat) HF org
- Seeded with [wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX](https://huggingface.co/wavekat/Qwen3-TTS-1.7B-VoiceDesign-ONNX); table is ready to grow as more backend weights are published

## Test plan
- [ ] Confirm the Model weights table renders on GitHub and the HF links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)