### PR TITLE
fix: auto-resample ref audio to 24 kHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ use wavekat_tts::backends::qwen3_tts::{Qwen3TtsClone, CloneRequest};
 // use wavekat_tts::backends::qwen3_tts::{ModelConfig, ModelPrecision};
 
 fn main() {
-    let ref_audio = AudioFrame::from_wav("ref.wav").unwrap(); // 24 kHz mono WAV
+    let ref_audio = AudioFrame::from_wav("ref.wav").unwrap();
+    let ref_audio = ref_audio.resample(24000).unwrap(); // resample to 24 kHz (no-op if already 24 kHz)
     let tts = Qwen3TtsClone::new().unwrap(); // auto-downloads 0.6B Base INT4 model
 
     // For FP32 precision:

--- a/crates/wavekat-tts/Cargo.toml
+++ b/crates/wavekat-tts/Cargo.toml
@@ -22,7 +22,7 @@ cuda     = ["ort?/cuda"]
 tensorrt = ["ort?/tensorrt"]
 
 [dependencies]
-wavekat-core = { version = "0.0.7", features = ["wav"] }
+wavekat-core = { version = "0.0.8", features = ["wav", "resample"] }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/wavekat-tts/examples/synthesize_clone.rs
+++ b/crates/wavekat-tts/examples/synthesize_clone.rs
@@ -113,14 +113,17 @@ fn main() {
     // Read reference audio WAV
     eprintln!("Reading reference audio: {} ...", ref_audio_path.display());
     let ref_audio = AudioFrame::from_wav(&ref_audio_path).expect("failed to read reference WAV");
-    if ref_audio.sample_rate() != 24000 {
+    let ref_audio = if ref_audio.sample_rate() != 24000 {
         eprintln!(
-            "error: reference audio must be 24 kHz, got {} Hz",
+            "  resampling from {} Hz to 24000 Hz ...",
             ref_audio.sample_rate()
         );
-        eprintln!("hint: resample with: ffmpeg -i input.wav -ar 24000 -ac 1 ref_24k.wav");
-        std::process::exit(1);
-    }
+        ref_audio
+            .resample(24000)
+            .expect("failed to resample reference audio")
+    } else {
+        ref_audio
+    };
     eprintln!(
         "  {:.1}s, {} Hz, {} samples",
         ref_audio.duration_secs(),


### PR DESCRIPTION
## Summary
- Bump `wavekat-core` to 0.0.8 and enable the new `resample` feature
- Replace the hard error in `synthesize_clone` example with automatic resampling via `AudioFrame::resample()`
- Users can now pass reference audio at any sample rate (e.g. 44.1 kHz) without manual ffmpeg conversion

## Test plan
- [x] `make check` passes (fmt, clippy, tests)
- [x] Run `cargo run --example synthesize_clone --features qwen3-tts -- --ref-audio ref_44k.wav --ref-text "..." --text "..."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)