### PR TITLE
docs: add stars chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ Composable with any backend flag. Selects the inference hardware at build time.
 | `tensorrt` | NVIDIA TensorRT | 🚧 Not configured |
 | `coreml` | Apple CoreML (macOS) | 🚧 Not configured |
 
+## Stars
+
+<a href="https://stars.wavekat.com/wavekat/wavekat-tts">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://stars.wavekat.com/wavekat/wavekat-tts/chart.svg?theme=dark">
+    <img alt="wavekat/wavekat-tts stars" src="https://stars.wavekat.com/wavekat/wavekat-tts/chart.svg?theme=light">
+  </picture>
+</a>
+
 ## License
 
 Licensed under [Apache 2.0](LICENSE).


### PR DESCRIPTION
Adds the auto-theme stars.wavekat.com embed before the License section.