### PR TITLE
docs: link wavekat.com from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![docs.rs](https://docs.rs/wavekat-tts/badge.svg)](https://docs.rs/wavekat-tts)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-wavekat%2Fwavekat--tts-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/wavekat/wavekat-tts)
 
-Unified text-to-speech for voice pipelines, wrapping multiple TTS engines
+Unified text-to-speech for [WaveKat](https://wavekat.com) voice pipelines, wrapping multiple TTS engines
 behind common Rust traits. 
 Same pattern as
 [wavekat-vad](https://github.com/wavekat/wavekat-vad) and
@@ -170,6 +170,12 @@ Composable with any backend flag. Selects the inference hardware at build time.
 | `cuda` | NVIDIA CUDA GPU | ✅ Working |
 | `tensorrt` | NVIDIA TensorRT | 🚧 Not configured |
 | `coreml` | Apple CoreML (macOS) | 🚧 Not configured |
+
+## About WaveKat
+
+`wavekat-tts` is part of WaveKat, an open-source ecosystem of Rust crates for building real-time voice pipelines. It handles text-to-speech, alongside sibling crates for voice activity detection, turn detection, and speech-to-text.
+
+See [wavekat.com](https://wavekat.com) for the full project.
 
 ## Stars
 


### PR DESCRIPTION
Adds an "About WaveKat" section linking to wavekat.com, and an inline link to the homepage in the intro where it fits naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)